### PR TITLE
Improve type safety for bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Then you can bind the dependency to a value, a function, a class, a factory, a h
 
 You can define a registry type or interface to get full type safety for your dependency injection keys and their corresponding types. This eliminates the need for manual casting when resolving dependencies.
 
+The container also validates that the dependencies you provide match what your classes or functions expect. TypeScript will catch errors at compile time such as omitting required dependencies or providing the wrong dependency types.
+
 ### Create the Registry
 
 Define a type or interface that maps your injection tokens to the desired types:

--- a/specs/examples/Registry.ts
+++ b/specs/examples/Registry.ts
@@ -9,6 +9,7 @@ export type TestRegistry = {
   'MY_USE_CASE': MyUseCase;
   'CLASS_WITH_DEPENDENCIES': ServiceClass;
   'CLASS_WITHOUT_DEPENDENCIES': ServiceClass;
+  'MY_CURRIED_FUNCTION': (name: string) => string;
 }
 
 export interface UserService {

--- a/specs/registry.spec.ts
+++ b/specs/registry.spec.ts
@@ -1,4 +1,4 @@
-﻿import {createContainer, TypedContainer} from '../src';
+﻿import {createContainer, createModule, TypedContainer, type TypedModule} from '../src';
 import {
   FakeLogger,
   ServiceClass,
@@ -8,6 +8,11 @@ import {
   simpleFunction,
   TestRegistry
 } from "./examples/Registry";
+import {
+  HigherOrderFunctionWithDependencies,
+  HigherOrderFunctionWithDependencyObject
+} from "./examples/HigherOrderFunctions";
+import { curriedFunctionWithDependencies } from "./examples/Currying";
 
 describe('Registry', () => {
   let container: TypedContainer<TestRegistry>;
@@ -215,6 +220,153 @@ describe('Registry', () => {
           dep1: DEP1,
           dep2: UNKNOWN_DEP
         });
+      });
+
+      it('should not allow wrong dependency types for array deps', () => {
+        // Arrange
+        const symbolContainer = createContainer<SymbolRegistry>();
+        symbolContainer.bind(DEP1).toValue('dep1');
+        symbolContainer.bind(DEP2).toValue(1);
+
+        // Act & Assert
+        // @ts-expect-error - DEP2 is number but dep1 expects string
+        symbolContainer.bind(CLASS_WITH_DEPENDENCIES).toClass(ServiceClassWithDeps, [DEP2, DEP1]);
+      });
+
+      it('should not allow wrong dependency types for object deps', () => {
+        // Arrange
+        const symbolContainer = createContainer<SymbolRegistry>();
+        symbolContainer.bind(DEP1).toValue('dep1');
+        symbolContainer.bind(DEP2).toValue(1);
+
+        // Act & Assert
+        // @ts-expect-error - DEP2 is number but dep1 expects string
+        symbolContainer.bind(CLASS_WITH_DEPENDENCIES).toClass(ServiceClassWithObjectDeps, {
+          dep1: DEP2,
+          dep2: DEP1
+        });
+      });
+    });
+
+    describe('When using string keys', () => {
+      it('should not allow wrong dependency types for array deps', () => {
+        // Arrange
+        container.bind('DEP1').toValue('dep1');
+        container.bind('DEP2').toValue(1);
+
+        // Act & Assert
+        // @ts-expect-error - DEP2 is number but dep1 expects string
+        container.bind('CLASS_WITH_DEPENDENCIES').toClass(ServiceClassWithDeps, ['DEP2', 'DEP1']);
+      });
+
+      it('should not allow wrong dependency types for object deps', () => {
+        // Arrange
+        container.bind('DEP1').toValue('dep1');
+        container.bind('DEP2').toValue(1);
+
+        // Act & Assert
+        // @ts-expect-error - DEP2 is number but dep1 expects string
+        container.bind('CLASS_WITH_DEPENDENCIES').toClass(ServiceClassWithObjectDeps, {
+          dep1: 'DEP2',
+          dep2: 'DEP1'
+        });
+      });
+
+      describe('toHigherOrderFunction()', () => {
+        it('should not allow wrong dependency types for array deps', () => {
+          // Arrange
+          container.bind('DEP1').toValue('dep1');
+          container.bind('DEP2').toValue(1);
+
+          // Act & Assert
+          // @ts-expect-error - DEP2 is number but dep1 expects string
+          container.bind('MY_SERVICE').toHigherOrderFunction(HigherOrderFunctionWithDependencies, ['DEP2', 'DEP1']);
+        });
+
+        it('should require dependencies when function requires them', () => {
+          // Act & Assert
+          // @ts-expect-error - omitting required dependencies
+          container.bind('MY_SERVICE').toHigherOrderFunction(HigherOrderFunctionWithDependencies);
+        });
+      });
+
+      describe('toCurry()', () => {
+        it('should not allow wrong dependency types for array deps', () => {
+          // Arrange
+          container.bind('DEP2').toValue(1);
+
+          // Act & Assert
+          // @ts-expect-error - DEP2 is number but dep1 expects string
+          container.bind('MY_CURRIED_FUNCTION').toCurry(curriedFunctionWithDependencies, ['DEP2']);
+        });
+
+        it('should require dependencies when function requires them', () => {
+          // Act & Assert
+          // @ts-expect-error - omitting required dependencies
+          container.bind('MY_CURRIED_FUNCTION').toCurry(curriedFunctionWithDependencies);
+        });
+      });
+
+      describe('toClass() with conditionally required dependencies', () => {
+        it('should require dependencies when constructor requires them', () => {
+          // Act & Assert
+          // @ts-expect-error - omitting required dependencies
+          container.bind('CLASS_WITH_DEPENDENCIES').toClass(ServiceClassWithDeps);
+        });
+
+        it('should allow omitting dependencies when constructor needs none', () => {
+          // Act & Assert - should not error
+          container.bind('CLASS_WITHOUT_DEPENDENCIES').toClass(ServiceClassNoDeps);
+        });
+      });
+    });
+
+    describe('When using a typed module', () => {
+      it('should not allow missing dependencies in toClass()', () => {
+        // Arrange
+        const mod = createModule<TestRegistry>();
+
+        // Act & Assert
+        // @ts-expect-error - empty object doesn't satisfy the required deps
+        mod.bind('CLASS_WITH_DEPENDENCIES').toClass(ServiceClassWithDeps, {});
+      });
+
+      it('should not allow wrong dependency types for array deps in toClass()', () => {
+        // Arrange
+        const mod = createModule<TestRegistry>();
+
+        // Act & Assert
+        // @ts-expect-error - DEP2 is number but dep1 expects string
+        mod.bind('CLASS_WITH_DEPENDENCIES').toClass(ServiceClassWithDeps, ['DEP2', 'DEP1']);
+      });
+
+      it('should not allow wrong dependency types for object deps in toClass()', () => {
+        // Arrange
+        const mod = createModule<TestRegistry>();
+
+        // Act & Assert
+        // @ts-expect-error - DEP2 is number but dep1 expects string
+        mod.bind('CLASS_WITH_DEPENDENCIES').toClass(ServiceClassWithObjectDeps, {
+          dep1: 'DEP2',
+          dep2: 'DEP1'
+        });
+      });
+
+      it('should require dependencies when constructor requires them', () => {
+        // Arrange
+        const mod = createModule<TestRegistry>();
+
+        // Act & Assert
+        // @ts-expect-error - omitting required dependencies
+        mod.bind('CLASS_WITH_DEPENDENCIES').toClass(ServiceClassWithDeps);
+      });
+
+      it('should allow omitting dependencies when constructor needs none', () => {
+        // Arrange
+        const mod = createModule<TestRegistry>();
+
+        // Act & Assert - should not error
+        mod.bind('CLASS_WITHOUT_DEPENDENCIES').toClass(ServiceClassNoDeps);
       });
     });
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,13 +16,48 @@ export interface DefaultRegistry {
 
 type RegistryKey<TRegistry> = Extract<keyof TRegistry, DependencyKey>;
 
-type RegistryDependencyArray<TRegistry> = readonly RegistryKey<TRegistry>[];
+// Find all registry keys whose resolved type extends T
+type KeysMatching<TRegistry, T> = {
+  [K in RegistryKey<TRegistry>]: TRegistry[K & keyof TRegistry] extends T
+    ? K
+    : never;
+}[RegistryKey<TRegistry>];
 
-type RegistryDependencyObject<TRegistry> = {
-  [key: string]: RegistryKey<TRegistry>;
+// For each position in a params tuple, compute the valid registry keys
+type ValidatedArrayDeps<TRegistry, TParams extends readonly unknown[]> = {
+  readonly [I in keyof TParams]: KeysMatching<TRegistry, TParams[I]>;
 };
 
-type RegistryDependencies<TRegistry> = RegistryDependencyArray<TRegistry> | RegistryDependencyObject<TRegistry>;
+// For a single object parameter, map each property to valid registry keys
+type ValidatedObjectDeps<TRegistry, TParam> = {
+  [P in keyof TParam]: KeysMatching<TRegistry, TParam[P]>;
+};
+
+// Shared core, validate deps against a parameter tuple
+type ValidDepsForParams<
+  TRegistry,
+  TParams extends readonly unknown[]
+> = TParams extends readonly []
+  ? never
+  : TParams extends readonly [infer Only, ...infer Rest]
+  ? Rest extends []
+    ? Only extends Record<string, unknown>
+      ? ValidatedArrayDeps<TRegistry, [Only]> | ValidatedObjectDeps<TRegistry, Only>
+      : ValidatedArrayDeps<TRegistry, [Only]>
+    : ValidatedArrayDeps<TRegistry, TParams>
+  : never;
+
+// Combine valid dependencies for a given constructor
+type ValidDepsFor<
+  TRegistry,
+  TClass extends new (...args: any[]) => any
+> = ValidDepsForParams<TRegistry, ConstructorParameters<TClass>>;
+
+// Combine valid dependencies for a given function
+type ValidFnDepsFor<
+  TRegistry,
+  TFn extends (...args: any[]) => any
+> = ValidDepsForParams<TRegistry, Parameters<TFn>>;
 
 type IncompatibleOverride<K extends PropertyKey, Expected, Provided> = {
   __error: 'Incompatible override type for registry key';
@@ -67,22 +102,43 @@ interface TypedBindable<TRegistry> {
   bind<K extends RegistryKey<TRegistry>>(key: K): {
     toValue: (value: TRegistry[K]) => void;
     toFunction: (fn: CallableFunction) => void;
-    toHigherOrderFunction: (
-      fn: CallableFunction,
-      dependencies?: RegistryDependencies<TRegistry>,
-      scope?: Scope
-    ) => void;
-    toCurry: (
-      fn: CallableFunction,
-      dependencies?: RegistryDependencies<TRegistry>,
-      scope?: Scope
-    ) => void;
+    toHigherOrderFunction: {
+      <TFn extends (...args: readonly []) => TRegistry[K]>(
+        fn: TFn,
+        dependencies?: undefined,
+        scope?: Scope
+      ): void;
+      <TFn extends (...args: any[]) => TRegistry[K]>(
+        fn: TFn,
+        dependencies: ValidFnDepsFor<TRegistry, TFn>,
+        scope?: Scope
+      ): void;
+    };
+    toCurry: {
+      <TFn extends (...args: readonly []) => TRegistry[K]>(
+        fn: TFn,
+        dependencies?: undefined,
+        scope?: Scope
+      ): void;
+      <TFn extends (...args: any[]) => TRegistry[K]>(
+        fn: TFn,
+        dependencies: ValidFnDepsFor<TRegistry, TFn>,
+        scope?: Scope
+      ): void;
+    };
     toFactory: (factory: CallableFunction, scope?: Scope) => void;
-    toClass: <C>(
-      constructor: new (...args: any[]) => C,
-      dependencies?: RegistryDependencies<TRegistry>,
-      scope?: Scope
-    ) => void;
+    toClass: {
+      <TClass extends new () => TRegistry[K]>(
+        constructor: TClass,
+        dependencies?: undefined,
+        scope?: Scope
+      ): void;
+      <TClass extends new (...args: any[]) => TRegistry[K]>(
+        constructor: TClass,
+        dependencies: ValidDepsFor<TRegistry, TClass>,
+        scope?: Scope
+      ): void;
+    };
   };
 
   bind(key: DependencyKey): {
@@ -121,22 +177,43 @@ export interface TypedContainer<TRegistry> {
   bind<K extends RegistryKey<TRegistry>>(key: K): {
     toValue: (value: TRegistry[K]) => void;
     toFunction: (fn: TRegistry[K] extends CallableFunction ? TRegistry[K] : never) => void;
-    toHigherOrderFunction: (
-      fn: CallableFunction,
-      dependencies?: RegistryDependencies<TRegistry>,
-      scope?: Scope
-    ) => void;
-    toCurry: (
-      fn: CallableFunction,
-      dependencies?: RegistryDependencies<TRegistry>,
-      scope?: Scope
-    ) => void;
+    toHigherOrderFunction: {
+      <TFn extends (...args: readonly []) => TRegistry[K]>(
+        fn: TFn,
+        dependencies?: undefined,
+        scope?: Scope
+      ): void;
+      <TFn extends (...args: any[]) => TRegistry[K]>(
+        fn: TFn,
+        dependencies: ValidFnDepsFor<TRegistry, TFn>,
+        scope?: Scope
+      ): void;
+    };
+    toCurry: {
+      <TFn extends (...args: readonly []) => TRegistry[K]>(
+        fn: TFn,
+        dependencies?: undefined,
+        scope?: Scope
+      ): void;
+      <TFn extends (...args: any[]) => TRegistry[K]>(
+        fn: TFn,
+        dependencies: ValidFnDepsFor<TRegistry, TFn>,
+        scope?: Scope
+      ): void;
+    };
     toFactory: (factory: (resolve: (key: DependencyKey) => unknown) => TRegistry[K], scope?: Scope) => void;
-    toClass: (
-      constructor: new (...args: any[]) => TRegistry[K],
-      dependencies?: RegistryDependencies<TRegistry>,
-      scope?: Scope
-    ) => void;
+    toClass: {
+      <TClass extends new () => TRegistry[K]>(
+        constructor: TClass,
+        dependencies?: undefined,
+        scope?: Scope
+      ): void;
+      <TClass extends new (...args: any[]) => TRegistry[K]>(
+        constructor: TClass,
+        dependencies: ValidDepsFor<TRegistry, TClass>,
+        scope?: Scope
+      ): void;
+    };
   };
 
   load<TModuleRegistry>(moduleKey: ModuleKey, module: TypedModule<TModuleRegistry>): void;


### PR DESCRIPTION
Thanks for writing ioctopus! We've used it in a handful of Next.js apps and it's been very helpful. There's one place where I felt it could be improved though, and that's with type safety around bindings. Currently ioctopus doesn't verify that the dependencies being passed to `toClass()`, `toHigherOrderFunction()` or `toCurry()` are actually the correct types. 

This PR adds type safety so that bindings like:

```ts
container.bind("MY_CLASS").toClass(MyClass, ["DEP1", "DEP2"])
```

actually check that the types of DEP1 and DEP2 match the arguments to MyClass's constructor. 

The same thing applies for deps objects like:

```ts
container.bind("MY_CLASS").toClass(MyClass, { dep1: "DEP1", dep2: "DEP2" })
```

These changes are purely to the TypeScript types, and don't actually change any of the runtime code in ioctopus. Thanks again, and let me know if you have any questions.