### PR TITLE
fix(types): avoid tuple-only regression and validate typed module bindings

### DIFF
--- a/specs/registry.spec.ts
+++ b/specs/registry.spec.ts
@@ -1,4 +1,4 @@
-﻿import {createContainer, createModule, TypedContainer, type TypedModule} from '../src';
+﻿import {createContainer, createModule, TypedContainer} from '../src';
 import {
   FakeLogger,
   ServiceClass,
@@ -9,10 +9,9 @@ import {
   TestRegistry
 } from "./examples/Registry";
 import {
-  HigherOrderFunctionWithDependencies,
-  HigherOrderFunctionWithDependencyObject
+  HigherOrderFunctionWithDependencies
 } from "./examples/HigherOrderFunctions";
-import { curriedFunctionWithDependencies } from "./examples/Currying";
+import {curriedFunctionWithDependencies} from "./examples/Currying";
 
 describe('Registry', () => {
   let container: TypedContainer<TestRegistry>;
@@ -241,10 +240,7 @@ describe('Registry', () => {
 
         // Act & Assert
         // @ts-expect-error - DEP2 is number but dep1 expects string
-        symbolContainer.bind(CLASS_WITH_DEPENDENCIES).toClass(ServiceClassWithObjectDeps, {
-          dep1: DEP2,
-          dep2: DEP1
-        });
+        symbolContainer.bind(CLASS_WITH_DEPENDENCIES).toClass(ServiceClassWithObjectDeps, {dep1: DEP2, dep2: DEP1});
       });
     });
 
@@ -266,10 +262,17 @@ describe('Registry', () => {
 
         // Act & Assert
         // @ts-expect-error - DEP2 is number but dep1 expects string
-        container.bind('CLASS_WITH_DEPENDENCIES').toClass(ServiceClassWithObjectDeps, {
-          dep1: 'DEP2',
-          dep2: 'DEP1'
-        });
+        container.bind('CLASS_WITH_DEPENDENCIES').toClass(ServiceClassWithObjectDeps, {dep1: 'DEP2', dep2: 'DEP1'});
+      });
+
+      it('should allow dependency arrays stored in typed variables for classes', () => {
+        // Arrange
+        container.bind('DEP1').toValue('dep1');
+        container.bind('DEP2').toValue(1);
+        const dependencies: Array<'DEP1' | 'DEP2'> = ['DEP1', 'DEP2'];
+
+        // Act & Assert
+        container.bind('CLASS_WITH_DEPENDENCIES').toClass(ServiceClassWithDeps, dependencies);
       });
 
       describe('toHigherOrderFunction()', () => {
@@ -287,6 +290,16 @@ describe('Registry', () => {
           // Act & Assert
           // @ts-expect-error - omitting required dependencies
           container.bind('MY_SERVICE').toHigherOrderFunction(HigherOrderFunctionWithDependencies);
+        });
+
+        it('should allow dependency arrays stored in typed variables', () => {
+          // Arrange
+          container.bind('DEP1').toValue('dep1');
+          container.bind('DEP2').toValue(1);
+          const dependencies: Array<'DEP1' | 'DEP2'> = ['DEP1', 'DEP2'];
+
+          // Act & Assert
+          container.bind('MY_SERVICE').toHigherOrderFunction(HigherOrderFunctionWithDependencies, dependencies);
         });
       });
 
@@ -315,7 +328,7 @@ describe('Registry', () => {
         });
 
         it('should allow omitting dependencies when constructor needs none', () => {
-          // Act & Assert - should not error
+          // Act & Assert
           container.bind('CLASS_WITHOUT_DEPENDENCIES').toClass(ServiceClassNoDeps);
         });
       });
@@ -324,49 +337,64 @@ describe('Registry', () => {
     describe('When using a typed module', () => {
       it('should not allow missing dependencies in toClass()', () => {
         // Arrange
-        const mod = createModule<TestRegistry>();
+        const module = createModule<TestRegistry>();
 
         // Act & Assert
         // @ts-expect-error - empty object doesn't satisfy the required deps
-        mod.bind('CLASS_WITH_DEPENDENCIES').toClass(ServiceClassWithDeps, {});
+        module.bind('CLASS_WITH_DEPENDENCIES').toClass(ServiceClassWithDeps, {});
       });
 
       it('should not allow wrong dependency types for array deps in toClass()', () => {
         // Arrange
-        const mod = createModule<TestRegistry>();
+        const module = createModule<TestRegistry>();
 
         // Act & Assert
         // @ts-expect-error - DEP2 is number but dep1 expects string
-        mod.bind('CLASS_WITH_DEPENDENCIES').toClass(ServiceClassWithDeps, ['DEP2', 'DEP1']);
+        module.bind('CLASS_WITH_DEPENDENCIES').toClass(ServiceClassWithDeps, ['DEP2', 'DEP1']);
       });
 
       it('should not allow wrong dependency types for object deps in toClass()', () => {
         // Arrange
-        const mod = createModule<TestRegistry>();
+        const module = createModule<TestRegistry>();
 
         // Act & Assert
         // @ts-expect-error - DEP2 is number but dep1 expects string
-        mod.bind('CLASS_WITH_DEPENDENCIES').toClass(ServiceClassWithObjectDeps, {
-          dep1: 'DEP2',
-          dep2: 'DEP1'
-        });
+        module.bind('CLASS_WITH_DEPENDENCIES').toClass(ServiceClassWithObjectDeps, {dep1: 'DEP2', dep2: 'DEP1'});
       });
 
       it('should require dependencies when constructor requires them', () => {
         // Arrange
-        const mod = createModule<TestRegistry>();
+        const module = createModule<TestRegistry>();
 
         // Act & Assert
         // @ts-expect-error - omitting required dependencies
-        mod.bind('CLASS_WITH_DEPENDENCIES').toClass(ServiceClassWithDeps);
+        module.bind('CLASS_WITH_DEPENDENCIES').toClass(ServiceClassWithDeps);
       });
 
       it('should allow omitting dependencies when constructor needs none', () => {
         // Arrange
-        const mod = createModule<TestRegistry>();
+        const module = createModule<TestRegistry>();
 
-        // Act & Assert - should not error
-        mod.bind('CLASS_WITHOUT_DEPENDENCIES').toClass(ServiceClassNoDeps);
+        // Act & Assert
+        module.bind('CLASS_WITHOUT_DEPENDENCIES').toClass(ServiceClassNoDeps);
+      });
+
+      it('should type-check toFunction() against the registry', () => {
+        // Arrange
+        const module = createModule<TestRegistry>();
+
+        // Act & Assert
+        // @ts-expect-error - function signature does not match the registry
+        module.bind('SIMPLE_FUNCTION').toFunction((name: string) => name);
+      });
+
+      it('should type-check toFactory() against the registry', () => {
+        // Arrange
+        const module = createModule<TestRegistry>();
+
+        // Act & Assert
+        // @ts-expect-error - factory return type does not match the registry
+        module.bind('CONFIG').toFactory(() => 123);
       });
     });
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,48 +16,47 @@ export interface DefaultRegistry {
 
 type RegistryKey<TRegistry> = Extract<keyof TRegistry, DependencyKey>;
 
-// Find all registry keys whose resolved type extends T
-type KeysMatching<TRegistry, T> = {
+type MatchingRegistryKeys<TRegistry, T> = {
   [K in RegistryKey<TRegistry>]: TRegistry[K & keyof TRegistry] extends T
     ? K
     : never;
 }[RegistryKey<TRegistry>];
 
-// For each position in a params tuple, compute the valid registry keys
-type ValidatedArrayDeps<TRegistry, TParams extends readonly unknown[]> = {
-  readonly [I in keyof TParams]: KeysMatching<TRegistry, TParams[I]>;
+type ValidatedArrayDependencies<TRegistry, TParameters extends readonly unknown[]> = {
+  readonly [I in keyof TParameters]: MatchingRegistryKeys<TRegistry, TParameters[I]>;
 };
 
-// For a single object parameter, map each property to valid registry keys
-type ValidatedObjectDeps<TRegistry, TParam> = {
-  [P in keyof TParam]: KeysMatching<TRegistry, TParam[P]>;
+type NonTupleArray<T extends readonly unknown[]> = number extends T['length'] ? T : never;
+
+type CompatibleArrayDependencies<TRegistry, TParameters extends readonly unknown[]> =
+  readonly MatchingRegistryKeys<TRegistry, TParameters[number]>[];
+
+type ValidatedObjectDependencies<TRegistry, TParameter> = {
+  [P in keyof TParameter]: MatchingRegistryKeys<TRegistry, TParameter[P]>;
 };
 
-// Shared core, validate deps against a parameter tuple
-type ValidDepsForParams<
+type ValidDependenciesForParameters<
   TRegistry,
-  TParams extends readonly unknown[]
-> = TParams extends readonly []
+  TParameters extends readonly unknown[]
+> = TParameters extends readonly []
   ? never
-  : TParams extends readonly [infer Only, ...infer Rest]
+  : TParameters extends readonly [infer Only, ...infer Rest]
   ? Rest extends []
     ? Only extends Record<string, unknown>
-      ? ValidatedArrayDeps<TRegistry, [Only]> | ValidatedObjectDeps<TRegistry, Only>
-      : ValidatedArrayDeps<TRegistry, [Only]>
-    : ValidatedArrayDeps<TRegistry, TParams>
+      ? ValidatedArrayDependencies<TRegistry, [Only]> | ValidatedObjectDependencies<TRegistry, Only>
+      : ValidatedArrayDependencies<TRegistry, [Only]>
+    : ValidatedArrayDependencies<TRegistry, TParameters>
   : never;
 
-// Combine valid dependencies for a given constructor
-type ValidDepsFor<
+type ValidDependenciesFor<
   TRegistry,
   TClass extends new (...args: any[]) => any
-> = ValidDepsForParams<TRegistry, ConstructorParameters<TClass>>;
+> = ValidDependenciesForParameters<TRegistry, ConstructorParameters<TClass>>;
 
-// Combine valid dependencies for a given function
-type ValidFnDepsFor<
+type ValidFunctionDependenciesFor<
   TRegistry,
-  TFn extends (...args: any[]) => any
-> = ValidDepsForParams<TRegistry, Parameters<TFn>>;
+  TFunction extends (...args: any[]) => any
+> = ValidDependenciesForParameters<TRegistry, Parameters<TFunction>>;
 
 type IncompatibleOverride<K extends PropertyKey, Expected, Provided> = {
   __error: 'Incompatible override type for registry key';
@@ -101,32 +100,42 @@ interface Bindable {
 interface TypedBindable<TRegistry> {
   bind<K extends RegistryKey<TRegistry>>(key: K): {
     toValue: (value: TRegistry[K]) => void;
-    toFunction: (fn: CallableFunction) => void;
+    toFunction: (fn: TRegistry[K] extends CallableFunction ? TRegistry[K] : never) => void;
     toHigherOrderFunction: {
-      <TFn extends (...args: readonly []) => TRegistry[K]>(
-        fn: TFn,
+      <TFunction extends (...args: readonly []) => TRegistry[K]>(
+        fn: TFunction,
         dependencies?: undefined,
         scope?: Scope
       ): void;
-      <TFn extends (...args: any[]) => TRegistry[K]>(
-        fn: TFn,
-        dependencies: ValidFnDepsFor<TRegistry, TFn>,
+      <TFunction extends (...args: any[]) => TRegistry[K]>(
+        fn: TFunction,
+        dependencies: ValidFunctionDependenciesFor<TRegistry, TFunction>,
+        scope?: Scope
+      ): void;
+      <TFunction extends (...args: any[]) => TRegistry[K], const TDependencies extends CompatibleArrayDependencies<TRegistry, Parameters<TFunction>>>(
+        fn: TFunction,
+        dependencies: NonTupleArray<TDependencies>,
         scope?: Scope
       ): void;
     };
     toCurry: {
-      <TFn extends (...args: readonly []) => TRegistry[K]>(
-        fn: TFn,
+      <TFunction extends (...args: readonly []) => TRegistry[K]>(
+        fn: TFunction,
         dependencies?: undefined,
         scope?: Scope
       ): void;
-      <TFn extends (...args: any[]) => TRegistry[K]>(
-        fn: TFn,
-        dependencies: ValidFnDepsFor<TRegistry, TFn>,
+      <TFunction extends (...args: any[]) => TRegistry[K]>(
+        fn: TFunction,
+        dependencies: ValidFunctionDependenciesFor<TRegistry, TFunction>,
+        scope?: Scope
+      ): void;
+      <TFunction extends (...args: any[]) => TRegistry[K], const TDependencies extends CompatibleArrayDependencies<TRegistry, Parameters<TFunction>>>(
+        fn: TFunction,
+        dependencies: NonTupleArray<TDependencies>,
         scope?: Scope
       ): void;
     };
-    toFactory: (factory: CallableFunction, scope?: Scope) => void;
+    toFactory: (factory: (resolve: (key: DependencyKey) => unknown) => TRegistry[K], scope?: Scope) => void;
     toClass: {
       <TClass extends new () => TRegistry[K]>(
         constructor: TClass,
@@ -135,7 +144,12 @@ interface TypedBindable<TRegistry> {
       ): void;
       <TClass extends new (...args: any[]) => TRegistry[K]>(
         constructor: TClass,
-        dependencies: ValidDepsFor<TRegistry, TClass>,
+        dependencies: ValidDependenciesFor<TRegistry, TClass>,
+        scope?: Scope
+      ): void;
+      <TClass extends new (...args: any[]) => TRegistry[K], const TDependencies extends CompatibleArrayDependencies<TRegistry, ConstructorParameters<TClass>>>(
+        constructor: TClass,
+        dependencies: NonTupleArray<TDependencies>,
         scope?: Scope
       ): void;
     };
@@ -178,26 +192,36 @@ export interface TypedContainer<TRegistry> {
     toValue: (value: TRegistry[K]) => void;
     toFunction: (fn: TRegistry[K] extends CallableFunction ? TRegistry[K] : never) => void;
     toHigherOrderFunction: {
-      <TFn extends (...args: readonly []) => TRegistry[K]>(
-        fn: TFn,
+      <TFunction extends (...args: readonly []) => TRegistry[K]>(
+        fn: TFunction,
         dependencies?: undefined,
         scope?: Scope
       ): void;
-      <TFn extends (...args: any[]) => TRegistry[K]>(
-        fn: TFn,
-        dependencies: ValidFnDepsFor<TRegistry, TFn>,
+      <TFunction extends (...args: any[]) => TRegistry[K]>(
+        fn: TFunction,
+        dependencies: ValidFunctionDependenciesFor<TRegistry, TFunction>,
+        scope?: Scope
+      ): void;
+      <TFunction extends (...args: any[]) => TRegistry[K], const TDependencies extends CompatibleArrayDependencies<TRegistry, Parameters<TFunction>>>(
+        fn: TFunction,
+        dependencies: NonTupleArray<TDependencies>,
         scope?: Scope
       ): void;
     };
     toCurry: {
-      <TFn extends (...args: readonly []) => TRegistry[K]>(
-        fn: TFn,
+      <TFunction extends (...args: readonly []) => TRegistry[K]>(
+        fn: TFunction,
         dependencies?: undefined,
         scope?: Scope
       ): void;
-      <TFn extends (...args: any[]) => TRegistry[K]>(
-        fn: TFn,
-        dependencies: ValidFnDepsFor<TRegistry, TFn>,
+      <TFunction extends (...args: any[]) => TRegistry[K]>(
+        fn: TFunction,
+        dependencies: ValidFunctionDependenciesFor<TRegistry, TFunction>,
+        scope?: Scope
+      ): void;
+      <TFunction extends (...args: any[]) => TRegistry[K], const TDependencies extends CompatibleArrayDependencies<TRegistry, Parameters<TFunction>>>(
+        fn: TFunction,
+        dependencies: NonTupleArray<TDependencies>,
         scope?: Scope
       ): void;
     };
@@ -210,7 +234,12 @@ export interface TypedContainer<TRegistry> {
       ): void;
       <TClass extends new (...args: any[]) => TRegistry[K]>(
         constructor: TClass,
-        dependencies: ValidDepsFor<TRegistry, TClass>,
+        dependencies: ValidDependenciesFor<TRegistry, TClass>,
+        scope?: Scope
+      ): void;
+      <TClass extends new (...args: any[]) => TRegistry[K], const TDependencies extends CompatibleArrayDependencies<TRegistry, ConstructorParameters<TClass>>>(
+        constructor: TClass,
+        dependencies: NonTupleArray<TDependencies>,
         scope?: Scope
       ): void;
     };


### PR DESCRIPTION
This updates the typing improvements from the last commit without changing runtime behavior.

It keeps the new compile-time validation for toClass(), toHigherOrderFunction(), and toCurry(), but fixes a regression where valid dependency arrays stored in typed variables were no longer accepted unless written as inline tuples. It also tightens TypedModule so toFunction() and toFactory() are validated against the registry, bringing it in line with TypedContainer.

In addition, the tests were expanded to cover those cases, and the new code was adjusted to match the project’s comment and naming conventions.